### PR TITLE
Force encoding of file coming from open-uri

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -11,7 +11,7 @@ require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
 
 def reprocess_csv(file)
-  raw = open(file).read
+  raw = open(file).read.force_encoding("UTF-8")
   csv = CSV.parse(raw.lines.drop(2).join)
   csv.each do |row|
     next if row[0].to_s.empty?


### PR DESCRIPTION
For some reason the downloaded file is interpreted by open-uri as
being ASCII when it's supposed to be UTF-8 and seems to be correctly
served as that by Google. Forcing the correct encoding makes sure that
encoding flows down to the parsed CSV data and ultimately the SQLite
database.

You'll need to delete your database for this to work, I'm guessing
because the database encoding is set when it's created.
